### PR TITLE
Fix the error caused by the missing database prefix in the WHERE clause.

### DIFF
--- a/Model/ResourceModel/EventProductPrice.php
+++ b/Model/ResourceModel/EventProductPrice.php
@@ -82,7 +82,7 @@ class EventProductPrice extends AbstractDb
             ->from($this->getTable($this->getMainTable()), ['product_id', 'price', 'event_id', 'discount_amount'])
             ->where('`start_date` <= ?', $date)
             ->where('`end_date` >= ?', $date)
-            ->where('deki_flashsale_event_product_price.product_id IN(?)', $productIds, \Zend_Db::INT_TYPE);
+            ->where($this->getTable('deki_flashsale_event_product_price').'.product_id IN(?)', $productIds, \Zend_Db::INT_TYPE);
 
         /**
          * Exclude from flash sale if qty is 0 (real time).
@@ -90,8 +90,8 @@ class EventProductPrice extends AbstractDb
          */
         $select->join(
             ['ev' => $this->getTable('deki_flashsale_event_product')],
-            'ev.product_id = deki_flashsale_event_product_price.product_id'
-            .' AND ev.event_id = deki_flashsale_event_product_price.event_id',
+            'ev.product_id = '.$this->getTable('deki_flashsale_event_product_price').'.product_id'
+            .' AND ev.event_id = '.$this->getTable('deki_flashsale_event_product_price').'.event_id',
             [
                 'qty' => 'ev.qty',
                 'flash_sale_event_product_id' => 'ev.event_product_id',


### PR DESCRIPTION
After installing the module, the following error occurred on the frontend, which has been fixed.

![image](https://github.com/user-attachments/assets/ac4c3409-4898-47b2-98b1-f710f33263a4)
